### PR TITLE
Supports determines the MongoDB nodes from which to read.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ Add plugin to a schema and then use model `paginate` method:
 const mongoose         = require('mongoose');
 const mongoosePaginate = require('mongoose-paginate-v2');
 
-const mySchema = new mongoose.Schema({ 
-  /* your schema definition */ 
+const mySchema = new mongoose.Schema({
+  /* your schema definition */
 });
 
 mySchema.plugin(mongoosePaginate);
 
-const myModel = mongoose.model('SampleModel',  mySchema); 
+const myModel = mongoose.model('SampleModel',  mySchema);
 
 myModel.paginate().then({}) // Usage
 ```
@@ -47,9 +47,9 @@ Returns promise
 
 * `[query]` {Object} - Query criteria. [Documentation](https://docs.mongodb.org/manual/tutorial/query-documents)
 * `[options]` {Object}
-  - `[select]` {Object | String} - Fields to return (by default returns all fields). [Documentation](http://mongoosejs.com/docs/api.html#query_Query-select) 
+  - `[select]` {Object | String} - Fields to return (by default returns all fields). [Documentation](http://mongoosejs.com/docs/api.html#query_Query-select)
   - `[collation]` {Object} - Specify the collation [Documentation](https://docs.mongodb.com/manual/reference/collation/)
-  - `[sort]` {Object | String} - Sort order. [Documentation](http://mongoosejs.com/docs/api.html#query_Query-sort) 
+  - `[sort]` {Object | String} - Sort order. [Documentation](http://mongoosejs.com/docs/api.html#query_Query-sort)
   - `[populate]` {Array | Object | String} - Paths which should be populated with other documents. [Documentation](http://mongoosejs.com/docs/api.html#query_Query-populate)
   - `[lean=false]` {Boolean} - Should return plain javascript objects instead of Mongoose documents?  [Documentation](http://mongoosejs.com/docs/api.html#query_Query-lean)
   - `[leanWithId=true]` {Boolean} - If `lean` and `leanWithId` are `true`, adds `id` field with string representation of `_id` to every document
@@ -58,6 +58,18 @@ Returns promise
   - `[limit=10]` {Number}
   - `[customLabels]` {Object} - Developers can provide custom labels for manipulating the response data.
   - `[pagination]` {Boolean} - If `pagination` is set to false, it will return all docs without adding limit condition. (Default: True)
+  - `[read]` {Object} - Determines the MongoDB nodes from which to read.
+    - Options
+      - `[pref]`: One of the listed preference options or aliases.
+      - `[tags]`: Optional tags for this query. (Must be used with `[pref]`)
+    - ```js
+      {
+        pref: 'secondary',
+        tags: [{
+          region: 'South'
+        }]
+      }
+      ```
 * `[callback(err, result)]` - If specified the callback is called once pagination results are retrieved or when an error has occurred
 
 **Return value**
@@ -69,7 +81,7 @@ Promise fulfilled with object having properties:
 * `limit` {Number} - Limit that was used
 * `hasPrevPage` {Bool} - Availability of prev page.
 * `hasNextPage` {Bool} - Availability of next page.
-* `page` {Number} - Current page number 
+* `page` {Number} - Current page number
 * `totalPages` {Number} - Total number of pages.
 * `offset` {Number} - Only if specified or default `page`/`offset` values were used
 * `prevPage` {Number} - Previous page number if available or NULL
@@ -104,7 +116,7 @@ Model.paginate({}, options, function(err, result) {
   // result.totalDocs = 100
   // result.limit = 10
   // result.page = 1
-  // result.totalPages = 10    
+  // result.totalPages = 10
   // result.hasNextPage = true
   // result.nextPage = 2
   // result.hasPrevPage = false
@@ -196,7 +208,7 @@ var options = {
   sort:     { date: -1 },
   populate: 'author',
   lean:     true,
-  offset:   20, 
+  offset:   20,
   limit:    10
 };
 
@@ -213,7 +225,7 @@ You can use `limit=0` to get only metadata:
 Model.paginate({}, { limit: 0 }).then(function(result) {
   // result.docs - empty array
   // result.totalDocs
-  // result.limit - 0    
+  // result.limit - 0
 });
 ```
 
@@ -224,7 +236,7 @@ config.js:
 ```javascript
 var mongoosePaginate = require('mongoose-paginate-v2');
 
-mongoosePaginate.paginate.options = { 
+mongoosePaginate.paginate.options = {
   lean:  true,
   limit: 20
 };
@@ -252,7 +264,7 @@ Model.paginate({}, options, function(err, result) {
   // result.totalDocs = 100
   // result.limit = 100
   // result.page = 1
-  // result.totalPages = 1    
+  // result.totalPages = 1
   // result.hasNextPage = false
   // result.nextPage = null
   // result.hasPrevPage = false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mongoose-paginate-v2",
-	"version": "1.3.52",
+	"version": "1.3.53",
 	"description": "A cursor based custom pagination library for Mongoose with customizable labels.",
 	"main": "dist/index.js",
 	"scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@
  * @param {Number}              [options.offset=0] - Use offset or page to set skip position
  * @param {Number}              [options.page=1]
  * @param {Number}              [options.limit=10]
+ * @param {Object}              [options.read={}] - Determines the MongoDB nodes from which to read.
  * @param {Function}            [callback]
  *
  * @returns {Promise}
@@ -56,6 +57,7 @@ function paginate(query, options, callback) {
     leanWithId,
     populate,
     projection,
+    read,
     select,
     sort,
     pagination
@@ -76,7 +78,6 @@ function paginate(query, options, callback) {
   let skip;
 
   let docsPromise = [];
-  let docs = [];
 
   // Labels
   const labelDocs = customLabels.docs;
@@ -110,6 +111,15 @@ function paginate(query, options, callback) {
     mQuery.select(select);
     mQuery.sort(sort);
     mQuery.lean(lean);
+
+    if (read && read.pref) {
+      /**
+       * Determines the MongoDB nodes from which to read.
+       * @param read.pref one of the listed preference options or aliases
+       * @param read.tags optional tags for this query
+       */
+      mQuery.read(read.pref, read.tags);
+    }
 
     // Hack for mongo < v3.4
     if (Object.keys(collation).length > 0) {


### PR DESCRIPTION
Hi 😃 

New feature supports `.read(pref, tags)` for load balancing.

```js
    const options: any = {
      lean: true,
      limit: 10,
      offset: 0,
      page: 1,
      populate: ['images', 'comments'],
      read: {
        pref: 'secondary'
      }
    };

    const articles = await Article.paginate({}, options);

    res.send(articles);
```


ref: https://github.com/Automattic/mongoose/blob/master/lib/query.js#L1008
```js
    /**
     * Determines the MongoDB nodes from which to read.
     * @param pref one of the listed preference options or aliases
     * @tags optional tags for this query
     */
    read(pref: string, tags?: any[]): this;
```

Regards.