### PR TITLE
Fix first page bug with page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -185,7 +185,7 @@ function paginate(query, options, callback) {
         if (page > 1) {
           meta[labelHasPrevPage] = true;
           meta[labelPrevPage] = (page - 1);
-        } else if (page == 1 && offset !== 0) {
+        } else if (page == 1 && offset && offset !== 0) {
           meta[labelHasPrevPage] = true;
           meta[labelPrevPage] = 1;
         } else {

--- a/tests/index.js
+++ b/tests/index.js
@@ -113,7 +113,34 @@ describe('mongoose-paginate', function () {
       expect(result.totalPages).to.equal(10);
     });
   });
+ 
+  it('first page with page and limit', function() {
+    var query = {
+      title: {
+        $in: [/Book/i],
+      },
+    };
 
+    var options = {
+      limit: 10,
+      page: 1,
+      lean: true,
+    };
+
+    return Book.paginate(query, options).then(result => {
+      expect(result.docs).to.have.length(10);
+      expect(result.totalDocs).to.equal(100);
+      expect(result.limit).to.equal(10);
+      expect(result.page).to.equal(1);
+      expect(result.pagingCounter).to.equal(1);
+      expect(result.hasPrevPage).to.equal(false);
+      expect(result.hasNextPage).to.equal(true);
+      expect(result.prevPage).to.equal(null);
+      expect(result.nextPage).to.equal(2);
+      expect(result.totalPages).to.equal(10);
+    });
+  });
+  
   it('with offset and limit (not page)', function () {
     var query = {
       title: {


### PR DESCRIPTION
Hello everyone, thank you for the great library.

Bug has been introduced in this commit: https://github.com/aravindnc/mongoose-paginate-v2/commit/2a2a70e4b6d12c6317e830c68816ee7c90bf27fd#diff-1fdf421c05c1140f6d71444ea2b27638R188

If we provide option `page` and not `offset` then this condition is always `true`:
```
 } else if (page == 1 && offset !== 0) {
 meta[labelHasPrevPage] = true;
```
As a result we have `prevPage` on a first page if we use `page` option.

To solve: we need to check if offset is defined before compare to 0

This PR would:
- fix the bug
- add a test case for a first page
