### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+services: mongodb
 node_js:
   - node
   - lts/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - node
+  - lts/*
+  - 10
+  - 9
+  - 8
+install:
+  - npm ci
+script:
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ node_js:
   - 9
   - 8
 install:
-  - npm ci
+  - npm install
 script:
   - npm test

--- a/tests/index.js
+++ b/tests/index.js
@@ -142,7 +142,7 @@ describe('mongoose-paginate', function () {
     });
   });
 
-	it('last page with page and limit', function() {
+  it('last page with page and limit', function() {
     var query = {
       title: {
         $in: [/Book/i],

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,6 +34,7 @@ describe('mongoose-paginate', function () {
 
   before(function (done) {
     mongoose.connect(MONGO_URI, {
+			useUnifiedTopology: true,
       useNewUrlParser: true
     }, done);
   });
@@ -140,7 +141,34 @@ describe('mongoose-paginate', function () {
       expect(result.totalPages).to.equal(10);
     });
   });
-  
+
+	it('last page with page and limit', function() {
+    var query = {
+      title: {
+        $in: [/Book/i],
+      },
+    };
+
+    var options = {
+      limit: 10,
+      page: 10,
+      lean: true,
+    };
+
+    return Book.paginate(query, options).then(result => {
+			expect(result.docs).to.have.length(10);
+      expect(result.totalDocs).to.equal(100);
+      expect(result.limit).to.equal(10);
+      expect(result.page).to.equal(10);
+      expect(result.pagingCounter).to.equal(91);
+      expect(result.hasPrevPage).to.equal(true);
+      expect(result.hasNextPage).to.equal(false);
+      expect(result.prevPage).to.equal(9);
+      expect(result.nextPage).to.equal(null);
+      expect(result.totalPages).to.equal(10);
+    });
+  });
+
   it('with offset and limit (not page)', function () {
     var query = {
       title: {

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,7 +34,7 @@ describe('mongoose-paginate', function () {
 
   before(function (done) {
     mongoose.connect(MONGO_URI, {
-			useUnifiedTopology: true,
+      useUnifiedTopology: true,
       useNewUrlParser: true
     }, done);
   });


### PR DESCRIPTION
It would be nice to use a CI tool to execute tests automatically on PR etc.

I suggest https://travis-ci.com/ - it's free for open source.

@aravindnc if you accept this request, you will need to add project at https://travis-ci.com/ after merge. And maybe put badges into README.md ;) 

Tests by Travis will be executed on the next commit after `.travis.yml` is added to the project.

This PR would:
- add `.travis.yml` to execute tests for node versions `latest`/`lts`/`10`/`9`/`8`
- add test case for a last page (a test opposite to https://github.com/aravindnc/mongoose-paginate-v2/pull/67)
- add `useUnifiedTopology: true` to `mongo.connect` in tests to avoid warning about deprecation. 