### PR TITLE
provide estimatedDocumentCount option, wich enable estimatedDocumentC…

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Returns promise
   - `[limit=10]` {Number}
   - `[customLabels]` {Object} - Developers can provide custom labels for manipulating the response data.
   - `[pagination]` {Boolean} - If `pagination` is set to false, it will return all docs without adding limit condition. (Default: True)
+  - `[estimatedDocumentCount]` - Use estimatedDocumentCount instead of countDocuments since it is faster for larger collections. If you need a accurate but slower count result set it to false. (Default: true)
   - `[forceCountFn]` {Boolean} - Set this to true, if you need to support $geo queries.
   - `[read]` {Object} - Determines the MongoDB nodes from which to read. Below are the available options.
     - `[pref]`: One of the listed preference options or aliases.

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@
  * @param {Number}              [options.offset=0] - Use offset or page to set skip position
  * @param {Number}              [options.page=1]
  * @param {Number}              [options.limit=10]
+ * @param {Boolean}             [options.estimatedDocumentCount=true] - Enable estimatedDocumentCount use for countPromise evaluation
  * @param {Object}              [options.read={}] - Determines the MongoDB nodes from which to read.
  * @param {Function}            [callback]
  *
@@ -41,6 +42,7 @@ const defaultOptions = {
   select: '',
   options: {},
   pagination: true,
+  estimatedDocumentCount: true,
   forceCountFn: false
 };
 
@@ -62,6 +64,7 @@ function paginate(query, options, callback) {
     select,
     sort,
     pagination,
+    estimatedDocumentCount,
     forceCountFn
   } = options;
 
@@ -109,8 +112,11 @@ function paginate(query, options, callback) {
   let countPromise;
 
   if (forceCountFn === true) {
+    // Deprecated since starting from MongoDB Node.JS driver v3.1 
     countPromise = this.count(query).exec();
-  } else {
+  } else if (estimatedDocumentCount === true) {
+    countPromise = this.estimatedDocumentCount(query).exec()
+  } else{
     countPromise = this.countDocuments(query).exec();
   }
 


### PR DESCRIPTION
provide estimatedDocumentCount option, wich enable estimatedDocumentCount function use for countPromise, with default value as true, as it is the most common use case. Update README.md documentation as well for reflect the change. Solves issue #96 and #89 where paginations querys from large collections was taking too much time