### PR TITLE
Fix hasPrevPage behaviour with limit > offset > 0

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -225,6 +225,9 @@ function paginate(query, options, callback) {
         if (page > 1) {
           meta[labelHasPrevPage] = true;
           meta[labelPrevPage] = page - 1;
+        } else if (page == 1 && typeof offset !== 'undefined' && offset !== 0) {
+          meta[labelHasPrevPage] = true;
+          meta[labelPrevPage] = 1;
         }
 
         // Set next page

--- a/tests/index.js
+++ b/tests/index.js
@@ -143,6 +143,34 @@ describe('mongoose-paginate', function () {
     });
   });
 
+  it('first page with page and limit, limit > doc.length, offset by one', function () {
+    var query = {
+      title: {
+        $in: [/Book/i],
+      },
+    };
+
+    var options = {
+      offset: 1,
+      limit: 200,
+      page: 1,
+      lean: true,
+    };
+
+    return Book.paginate(query, options).then((result) => {
+      expect(result.docs).to.have.length(100);
+      expect(result.totalDocs).to.equal(100);
+      expect(result.limit).to.equal(200);
+      expect(result.page).to.equal(1);
+      expect(result.pagingCounter).to.equal(1);
+      expect(result.hasPrevPage).to.equal(false);
+      expect(result.hasNextPage).to.equal(false);
+      expect(result.prevPage).to.equal(null);
+      expect(result.nextPage).to.equal(null);
+      expect(result.totalPages).to.equal(1);
+    });
+  });
+
   it('first page with page and limit', function () {
     var query = {
       title: {

--- a/tests/index.js
+++ b/tests/index.js
@@ -249,9 +249,9 @@ describe('mongoose-paginate', function () {
       expect(result.limit).to.equal(10);
       expect(result.page).to.equal(1);
       expect(result.pagingCounter).to.equal(1);
-      expect(result.hasPrevPage).to.equal(false);
+      expect(result.hasPrevPage).to.equal(true);
       expect(result.hasNextPage).to.equal(true);
-      expect(result.prevPage).to.equal(null);
+      expect(result.prevPage).to.equal(1);
       expect(result.nextPage).to.equal(2);
       expect(result.totalPages).to.equal(10);
     });


### PR DESCRIPTION
Revert for part of 277d3f3af4e58f5f0daa53dde661aa3a5624d9e4

The fix for issue #119 would be to set offset to 0 or do not pass it anyways.
@serjmac will lose the first record in the list on every query.
That's why hasPrevPage is correctly set to true.

I rely on the existing behaviour because if a user changes the number of elements per page (limit e.g. 5 > 10) and was already on page 2 of the previous query (e.g. offset 5) he needs to be able to go back to the complete page 1 starting at record 0.