### PR TITLE
Add customFind options

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Returns promise
     - `[pref]`: One of the listed preference options or aliases.
     - `[tags]`: Optional tags for this query. (Must be used with `[pref]`)
   - `[options]` {Object} - Options passed to Mongoose's `find()` function. [Documentation](https://mongoosejs.com/docs/api.html#query_Query-setOptions)
+  - `[customFind]` {String} - Method name for the find method which called from Model object. This options can be used to change default behaviour for pagination in case of different use cases (like [mongoose-soft-delete](https://github.com/dsanel/mongoose-delete#method-overridden)). (Default `'find'`)
 - `[callback(err, result)]` - If specified, the callback is called once pagination results are retrieved or when an error has occurred
 
 **Return value**

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ const defaultOptions = {
   useCustomCountFn: false,
   forceCountFn: false,
   allowDiskUse: false,
+  customFind: 'find',
 };
 
 function paginate(query, options, callback) {
@@ -73,6 +74,7 @@ function paginate(query, options, callback) {
     useCustomCountFn,
     forceCountFn,
     allowDiskUse,
+    customFind,
   } = options;
 
   const customLabels = {
@@ -151,7 +153,7 @@ function paginate(query, options, callback) {
   }
 
   if (limit) {
-    const mQuery = this.find(query, projection, findOptions);
+    const mQuery = this[customFind](query, projection, findOptions);
 
     if (populate) {
       mQuery.populate(populate);


### PR DESCRIPTION
Add `customFind` options to accept find method to use other than the mongoose's `find`. This will close #38 