### PR TITLE
fix: set limit when limit is 0

### DIFF
--- a/src/pagination-parameters.js
+++ b/src/pagination-parameters.js
@@ -98,7 +98,7 @@ class PaginationParametersHelper {
       options['leanWithId'] = this.booleanOpt(leanWithId);
     if (offset) options['offset'] = Number(offset);
     if (page) options['page'] = Number(page);
-    if (limit) options['limit'] = Number(limit);
+    if (limit || limit == 0) options['limit'] = Number(limit);
     if (customLabels)
       options['customLabels'] = this.optObjectOrString(customLabels);
     if (pagination !== undefined)


### PR DESCRIPTION
As described [here](https://github.com/aravindnc/mongoose-paginate-v2#zero-limit), `limit` should be able to be set to 0.

At the moment, when executing `new PaginationParameters({ query: { limit: 0 } }).getOptions()` result is `{}`. 
My patch will have it to return `{ limit: 0 }`.
