### PR TITLE
set dynamic type for `docs` items

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,30 @@ declare module 'mongoose' {
       ) => void
     ): Promise<PaginateResult<PaginateDocument<T, TMethods, O>>>;
   }
+
+  interface PaginateModel<T, TQueryHelpers = {}, TMethods = {}>
+    extends Model<T, TQueryHelpers, TMethods> {
+    paginate<UserType = T, O extends PaginateOptions = PaginateOptions >(
+      query?: FilterQuery<T>,
+      options?: O,
+      callback?: (
+        err: any,
+        result: PaginateResult<PaginateDocument<UserType, TMethods, O>>
+      ) => void
+    ): Promise<PaginateResult<PaginateDocument<UserType, TMethods, O>>>;
+  }
+
+  interface PaginateModel<T, TQueryHelpers = {}, TMethods = {}>
+    extends Model<T, TQueryHelpers, TMethods> {
+    paginate<UserType = T>(
+      query?: FilterQuery<T>,
+      options?: PaginateOptions,
+      callback?: (
+        err: any,
+        result: PaginateResult<PaginateDocument<UserType, TMethods, PaginateOptions>>
+      ) => void
+    ): Promise<PaginateResult<PaginateDocument<UserType, TMethods, PaginateOptions>>>;
+  }
 }
 
 import mongoose = require('mongoose');


### PR DESCRIPTION
Sequel to [this comment](https://github.com/aravindnc/mongoose-paginate-v2/issues/162#issuecomment-1721506125) in #162 

This PR aims to type the items in the `docs` field returned from calling the `paginate` function.
It uses [TypeScript function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to achieve this