### PR TITLE
fix: subdocs pagination count

### DIFF
--- a/src/pagination-subdocs.js
+++ b/src/pagination-subdocs.js
@@ -161,6 +161,7 @@ function paginateSubDocs(query, options, callback) {
         }
 
         populateResult(result, newPopulate).then((paginatedResult) => {
+          pagingOptions.count = result[newPopulate.path].length;
           // convert paginatedResult to pagination docs
           if (pagination && pagingOptions) {
             if (Array.isArray(pagingOptions)) {


### PR DESCRIPTION
- set count after result was populated (in case we have match filter etc)