### PR TITLE
MongoDB < 3.4: Fix for countDocument

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ function paginate(query, options, callback) {
           .collation(collation)
           .exec();
       } else {
-        countPromise = this.countDocuments(query, findOptions).exec();
+        countPromise = this.countDocuments(query).exec();
       }
     } else {
       if (useEstimatedCount === true) {
@@ -153,7 +153,7 @@ function paginate(query, options, callback) {
             .collation(collation)
             .exec();
         } else {
-          countPromise = this.countDocuments(query, findOptions).exec();
+          countPromise = this.countDocuments(query).exec();
         }
       }
     }


### PR DESCRIPTION
MongoDB < 3.4 is only supported by mongoose 5 or below
In mongoose 5, `Model.countDocument`'s signature is `Model.countDocuments = function countDocuments(conditions, callback) {...}`. 
```js
/**
 * Counts number of documents matching `filter` in a database collection.
 *
 * ####Example:
 *
 *     Adventure.countDocuments({ type: 'jungle' }, function (err, count) {
 *       console.log('there are %d jungle adventures', count);
 *     });
 *
 * If you want to count all documents in a large collection,
 * use the [`estimatedDocumentCount()` function](/docs/api.html#model_Model.estimatedDocumentCount)
 * instead. If you call `countDocuments({})`, MongoDB will always execute
 * a full collection scan and **not** use any indexes.
 *
 * The `countDocuments()` function is similar to `count()`, but there are a
 * [few operators that `countDocuments()` does not support](https://mongodb.github.io/node-mongodb-native/3.1/api/Collection.html#countDocuments).
 * Below are the operators that `count()` supports but `countDocuments()` does not,
 * and the suggested replacement:
 *
 * - `$where`: [`$expr`](https://docs.mongodb.com/manual/reference/operator/query/expr/)
 * - `$near`: [`$geoWithin`](https://docs.mongodb.com/manual/reference/operator/query/geoWithin/) with [`$center`](https://docs.mongodb.com/manual/reference/operator/query/center/#op._S_center)
 * - `$nearSphere`: [`$geoWithin`](https://docs.mongodb.com/manual/reference/operator/query/geoWithin/) with [`$centerSphere`](https://docs.mongodb.com/manual/reference/operator/query/centerSphere/#op._S_centerSphere)
 *
 * @param {Object} filter
 * @param {Function} [callback]
 * @return {Query}
 * @api public
 */

Model.countDocuments = function countDocuments(conditions, callback) {
  _checkContext(this, 'countDocuments');

  if (typeof conditions === 'function') {
    callback = conditions;
    conditions = {};
  }

  const mq = new this.Query({}, {}, this, this.$__collection);

  callback = this.$handleCallbackError(callback);

  return mq.countDocuments(conditions, callback);
};
```

Hence, passing `findOptions` as callback resulted in an error later saying expected parameter must be callback, not an object