### PR TITLE
make Query interface generics consistent with Mongoose 8.15 re: #218

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -146,16 +146,16 @@ declare module 'mongoose' {
   interface Query<
     ResultType,
     DocType,
-    THelpers = NonNullable<unknown>,
-    RawDocType = DocType,
+    THelpers = {},
+    RawDocType = unknown,
     QueryOp = 'find',
-    TInstanceMethods = Record<string, never>
+    TDocOverrides = Record<string, never>
   > {
     paginate<O extends PaginateOptions>(
       options?: O
     ): Promise<
       PaginateResult<
-        PaginateDocument<RawDocType, TInstanceMethods, THelpers, O>
+        PaginateDocument<RawDocType, TDocOverrides, THelpers, O>
       >
     >;
     paginate<
@@ -164,13 +164,13 @@ declare module 'mongoose' {
     >(
       options?: O
     ): Promise<
-      PaginateResult<PaginateDocument<UserType, TInstanceMethods, THelpers, O>>
+      PaginateResult<PaginateDocument<UserType, TDocOverrides, THelpers, O>>
     >;
     paginate<UserType = ResultType>(
       options?: PaginateOptions
     ): Promise<
       PaginateResult<
-        PaginateDocument<UserType, TInstanceMethods, THelpers, PaginateOptions>
+        PaginateDocument<UserType, TDocOverrides, THelpers, PaginateOptions>
       >
     >;
   }


### PR DESCRIPTION
#218 is a likely cause of #232 (and Automattic/mongoose#15423). In TypeScript 5, module augmentation generics need to be exactly identical, including default values and names. This PR makes it so that `interface Query`'s generics line up with Mongoose 8.9.3+.

Unfortunately can't make it line up exactly because Mongoose made some changes to `class Query` generics in 8.6.0 and 8.9.3 because we weren't aware that anyone was using module augmentation with Query. TBH we didn't even know you could use module augmentation with classes :face_with_diagonal_mouth: . Mongoose will keep this interface consistent in 8.x.