### PR TITLE
Update useCustomCountFn parameter type in documentation and implement…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@
  * @param {Number}              [options.page=1]
  * @param {Number}              [options.limit=10]
  * @param {Boolean}             [options.useEstimatedCount=true] - Enable estimatedDocumentCount for larger datasets. As the name says, the count may not abe accurate.
- * @param {Function}            [options.useCustomCountFn=false] - use custom function for count datasets.
+ * @param {(function(query: Object=): Promise<number>)} [options.useCustomCountFn=false] - Use custom function for count datasets. Receives `query` as an optional argument.
  * @param {Object}              [options.read={}] - Determines the MongoDB nodes from which to read.
  * @param {Function}            [callback]
  *
@@ -149,7 +149,7 @@ function paginate(query, options, callback) {
       if (useEstimatedCount === true) {
         countPromise = this.estimatedDocumentCount().exec();
       } else if (typeof useCustomCountFn === 'function') {
-        countPromise = useCustomCountFn();
+        countPromise = useCustomCountFn(query);
       } else {
         // Hack for mongo < v3.4
         if (Object.keys(collation).length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -143,7 +143,12 @@ function paginate(query, options, callback) {
           .collation(collation)
           .exec();
       } else {
-        countPromise = this.countDocuments(query).exec();
+        // Используем estimatedDocumentCount, если query пустой, иначе countDocuments
+        if (!query || Object.keys(query).length === 0) {
+          countPromise = this.estimatedDocumentCount().exec();
+        } else {
+          countPromise = this.countDocuments(query).exec();
+        }
       }
     } else {
       if (useEstimatedCount === true) {
@@ -157,7 +162,12 @@ function paginate(query, options, callback) {
             .collation(collation)
             .exec();
         } else {
-          countPromise = this.countDocuments(query).exec();
+          // Используем estimatedDocumentCount, если query пустой, иначе countDocuments
+          if (!query || Object.keys(query).length === 0) {
+            countPromise = this.estimatedDocumentCount().exec();
+          } else {
+            countPromise = this.countDocuments(query).exec();
+          }
         }
       }
     }


### PR DESCRIPTION
🚀 Improve Pagination Count Logic & Enhance Custom Count Function
Description:
This PR introduces two improvements to the pagination logic:

Use estimatedDocumentCount() When Query Is Empty
Pagination now uses estimatedDocumentCount() when the query object is empty, and falls back to countDocuments(query) when filters are present.

✨ Pass Query to useCustomCountFn
The useCustomCountFn option now receives the current query as an (optional) parameter, allowing for more flexible custom count logic.

Reasoning & Benefits:

⚡️ Performance:
estimatedDocumentCount() is much faster for unfiltered queries, as it uses collection metadata instead of scanning documents.

🔍 Accuracy:
For filtered queries, countDocuments(query) ensures the count matches the filter criteria.

🛠️ Extensibility:
Passing the query to useCustomCountFn enables advanced custom count scenarios that depend on the current query context.

📚 Best Practices:
Aligns with MongoDB recommendations for counting documents and improves documentation/type annotations.

🛡️ Backward Compatibility:
Existing behavior is preserved for filtered queries and for custom count functions that do not use the new parameter.

Summary of Changes:

🚄 Use estimatedDocumentCount() for empty queries to improve performance.
📝 Pass query as an (optional) parameter to useCustomCountFn.
📚 Update JSDoc/type annotations to reflect the new behavior.
No breaking changes:
If your custom count function does not use the new parameter, it will continue to work as before. 👍