### PR TITLE
fix: make offset field optional in PaginateResult type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -81,7 +81,7 @@ declare module 'mongoose' {
     hasNextPage: boolean;
     page?: number | undefined;
     totalPages: number;
-    offset: number;
+    offset?: number | undefined;
     prevPage?: number | null | undefined;
     nextPage?: number | null | undefined;
     pagingCounter: number;


### PR DESCRIPTION
## Description
This PR fixes a type definition inconsistency where the `offset` field in `PaginateResult` interface was marked as required, but the actual implementation only returns `offset` when explicitly provided in options.

## Problem
When using page-based pagination (without explicit offset), the runtime behavior doesn't include an `offset` field in the result, causing TypeScript type mismatches.

## Solution
- Changed `offset: number` to `offset?: number | undefined` in the `PaginateResult<T>` interface
- This aligns the TypeScript types with the actual runtime behavior

## Impact
This is a non-breaking change that only makes the type definition more accurate. All existing code will continue to work as expected.
