### PR TITLE
fix: exclude limit/skip from countDocuments options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,8 +95,26 @@ function paginate(query, options, callback) {
   const isCallbackSpecified = typeof callback === 'function';
   const findOptions = options.options;
 
-  // Create countOptions with collation included to preserve session context in transactions
+  // Create countOptions for countDocuments - exclude limit/skip which shouldn't be passed to count
+  // MongoDB's countDocuments applies limit to the count result, causing incorrect totalDocs
+  const countBaseOptions = {};
+  if (findOptions) {
+    if (findOptions.session) countBaseOptions.session = findOptions.session;
+    if (findOptions.hint) countBaseOptions.hint = findOptions.hint;
+    if (findOptions.readConcern)
+      countBaseOptions.readConcern = findOptions.readConcern;
+    if (findOptions.readPreference)
+      countBaseOptions.readPreference = findOptions.readPreference;
+    if (findOptions.maxTimeMS)
+      countBaseOptions.maxTimeMS = findOptions.maxTimeMS;
+  }
   const countOptions =
+    Object.keys(collation).length > 0
+      ? { ...countBaseOptions, collation }
+      : countBaseOptions;
+
+  // Create queryOptions for find - includes all options including collation
+  const queryOptions =
     Object.keys(collation).length > 0
       ? { ...findOptions, collation }
       : findOptions;
@@ -166,8 +184,8 @@ function paginate(query, options, callback) {
   }
 
   if (limit) {
-    // Use countOptions (which includes collation) to preserve session context in transactions
-    const mQuery = this[customFind](query, projection, countOptions);
+    // Use queryOptions (which includes collation and all find options) for the query
+    const mQuery = this[customFind](query, projection, queryOptions);
 
     if (populate) {
       mQuery.populate(populate);

--- a/src/index.js
+++ b/src/index.js
@@ -108,16 +108,13 @@ function paginate(query, options, callback) {
     if (findOptions.maxTimeMS)
       countBaseOptions.maxTimeMS = findOptions.maxTimeMS;
   }
-  const countOptions =
-    Object.keys(collation).length > 0
-      ? { ...countBaseOptions, collation }
-      : countBaseOptions;
 
-  // Create queryOptions for find - includes all options including collation
-  const queryOptions =
-    Object.keys(collation).length > 0
-      ? { ...findOptions, collation }
-      : findOptions;
+  let countOptions = countBaseOptions;
+  let queryOptions = findOptions;
+  if (Object.keys(collation).length > 0) {
+    countOptions = { ...countBaseOptions, collation };
+    queryOptions = { ...findOptions, collation };
+  }
 
   let offset;
   let page;

--- a/src/index.js
+++ b/src/index.js
@@ -95,26 +95,15 @@ function paginate(query, options, callback) {
   const isCallbackSpecified = typeof callback === 'function';
   const findOptions = options.options;
 
-  // Create countOptions for countDocuments - exclude limit/skip which shouldn't be passed to count
-  // MongoDB's countDocuments applies limit to the count result, causing incorrect totalDocs
-  const countBaseOptions = {};
-  if (findOptions) {
-    if (findOptions.session) countBaseOptions.session = findOptions.session;
-    if (findOptions.hint) countBaseOptions.hint = findOptions.hint;
-    if (findOptions.readConcern)
-      countBaseOptions.readConcern = findOptions.readConcern;
-    if (findOptions.readPreference)
-      countBaseOptions.readPreference = findOptions.readPreference;
-    if (findOptions.maxTimeMS)
-      countBaseOptions.maxTimeMS = findOptions.maxTimeMS;
-  }
+  // Create queryOptions with collation included to preserve session context in transactions
+  const queryOptions =
+    Object.keys(collation).length > 0
+      ? { ...findOptions, collation }
+      : findOptions;
 
-  let countOptions = countBaseOptions;
-  let queryOptions = findOptions;
-  if (Object.keys(collation).length > 0) {
-    countOptions = { ...countBaseOptions, collation };
-    queryOptions = { ...findOptions, collation };
-  }
+  // For countDocuments, exclude limit/skip which MongoDB applies to the count result
+  // eslint-disable-next-line no-unused-vars
+  const { limit: _l, skip: _s, ...countOptions } = queryOptions || {};
 
   let offset;
   let page;
@@ -181,7 +170,7 @@ function paginate(query, options, callback) {
   }
 
   if (limit) {
-    // Use queryOptions (which includes collation and all find options) for the query
+    // Use queryOptions (which includes collation) to preserve session context in transactions
     const mQuery = this[customFind](query, projection, queryOptions);
 
     if (populate) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -912,6 +912,40 @@ describe('mongoose-paginate', function () {
       await session.endSession();
     }
   });
+
+  it('should not pass limit from options.options to countDocuments', async function () {
+    // This test demonstrates a bug where limit in options.options gets passed to countDocuments.
+    // MongoDB's countDocuments applies the limit to the count result, causing incorrect totalDocs.
+    //
+    // When options.options = { limit: 10 } and collation is enabled:
+    //   countOptions = { ...findOptions, collation } = { limit: 10, collation: {...} }
+    //   this.countDocuments(query, countOptions).exec() // Returns max 10, not actual count!
+    //
+    // The fix: extract only valid countDocuments options (session, hint, etc.) and exclude
+    // limit/skip which are only meant for the find query.
+
+    const query = { active: true }; // Match all active books (50 of them)
+
+    const options = {
+      limit: 10,
+      page: 1,
+      collation: {
+        locale: 'en',
+        strength: 2,
+      },
+      options: {
+        limit: 10, // This should NOT be passed to countDocuments
+      },
+    };
+
+    const result = await Book.paginate(query, options);
+
+    // Bug: totalDocs returns 10 (the limit) instead of 50 (actual count)
+    expect(result.docs).to.have.length(10);
+    expect(result.totalDocs).to.equal(50); // This fails with the bug - returns 10
+    expect(result.totalPages).to.equal(5);
+    expect(result.hasNextPage).to.equal(true);
+  });
 });
 
 function randomString(strLength, charSet) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -855,6 +855,7 @@ describe('mongoose-paginate', function () {
   });
 
   it('collation with session in transaction should work correctly', async function () {
+    // Transactions require a replica set
     if (
       !mongoose.connection.client.topology.description.type.includes(
         'ReplicaSet'
@@ -863,18 +864,8 @@ describe('mongoose-paginate', function () {
       this.skip();
     }
 
-    // This test demonstrates a bug where collation + session in transaction
-    // causes a transaction mismatch error.
-    //
-    // The issue is in how collation is applied to countDocuments:
-    //   this.countDocuments(query, findOptions).collation(collation).exec()
-    //
-    // When findOptions contains a session inside a transaction and collation is chained,
-    // the session context is lost, causing transaction errors.
-    //
-    // The fix is to pass collation as part of the options object instead of chaining:
-    //   this.countDocuments(query, { ...findOptions, collation }).exec()
-
+    // Tests that collation + session in a transaction maintains session context.
+    // Previously, chaining .collation() after countDocuments broke the session.
     const session = await mongoose.startSession();
     session.startTransaction();
 
@@ -914,17 +905,10 @@ describe('mongoose-paginate', function () {
   });
 
   it('should not pass limit from options.options to countDocuments', async function () {
-    // This test demonstrates a bug where limit in options.options gets passed to countDocuments.
-    // MongoDB's countDocuments applies the limit to the count result, causing incorrect totalDocs.
-    //
-    // When options.options = { limit: 10 } and collation is enabled:
-    //   countOptions = { ...findOptions, collation } = { limit: 10, collation: {...} }
-    //   this.countDocuments(query, countOptions).exec() // Returns max 10, not actual count!
-    //
-    // The fix: extract only valid countDocuments options (session, hint, etc.) and exclude
-    // limit/skip which are only meant for the find query.
-
-    const query = { active: true }; // Match all active books (50 of them)
+    // When options.options contains { limit: 10 }, that limit was being passed to
+    // countDocuments(). MongoDB applies limit to the count result, so totalDocs
+    // would return 10 instead of the actual count (e.g., 50).
+    const query = { active: true };
 
     const options = {
       limit: 10,


### PR DESCRIPTION
## Summary

MongoDB's `countDocuments` applies `limit` to the count result when passed in the options object. When `options.options` contains a `limit` (commonly used for pagination), passing it to `countDocuments` causes `totalDocs` to return the limit value instead of the actual document count.

## Problem

When using pagination with collation and `options.options.limit`:

```javascript
const result = await Model.paginate({ active: true }, {
  limit: 10,
  collation: { locale: 'en', strength: 2 },
  options: { limit: 10 }
});
// Bug: result.totalDocs === 10 (should be actual count, e.g., 50)
```

## Solution

Create separate options objects:
- `countOptions`: only session, hint, collation, readConcern, readPreference, maxTimeMS (no limit/skip)
- `queryOptions`: all options including limit for the find query

## Test

Added test case that reproduces the bug and verifies the fix.