### PR TITLE
Fix concurrent pagination queries in transactions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,47 @@ const defaultOptions = {
   customFind: 'find',
 };
 
+function hasOwn(obj, key) {
+  return Object.prototype.hasOwnProperty.call(obj || {}, key);
+}
+
+function isSessionInTransaction(session) {
+  if (session == null) {
+    return false;
+  }
+
+  if (typeof session.inTransaction === 'function') {
+    return session.inTransaction();
+  }
+
+  // Older driver sessions may expose the driver session via `session.session`.
+  const driverSession = session.session;
+  if (driverSession && typeof driverSession.inTransaction === 'function') {
+    return driverSession.inTransaction();
+  }
+
+  // Pre-inTransaction drivers: conservatively serialize because we cannot
+  // determine whether the session is transactional. These drivers are too old
+  // to support causal sessions reliably anyway.
+  return true;
+}
+
+function hasActiveSession(model, queryOptions) {
+  if (hasOwn(queryOptions, 'session')) {
+    return isSessionInTransaction(queryOptions.session);
+  }
+
+  const base = model && model.db && model.db.base;
+  const als = base && base.transactionAsyncLocalStorage;
+
+  if (!als || typeof als.getStore !== 'function') {
+    return false;
+  }
+
+  const store = als.getStore();
+  return isSessionInTransaction(store && store.session);
+}
+
 function paginate(query, options, callback) {
   options = {
     ...defaultOptions,
@@ -169,9 +210,15 @@ function paginate(query, options, callback) {
     }
   }
 
-  if (limit) {
+  const model = this;
+
+  function buildDocsPromise() {
+    if (!limit) {
+      return Promise.resolve([]);
+    }
+
     // Use queryOptions (which includes collation) to preserve session context in transactions
-    const mQuery = this[customFind](query, projection, queryOptions);
+    const mQuery = model[customFind](query, projection, queryOptions);
 
     if (populate) {
       mQuery.populate(populate);
@@ -211,10 +258,10 @@ function paginate(query, options, callback) {
       console.error('Your MongoDB version does not support `allowDiskUse`.');
     }
 
-    docsPromise = mQuery.exec();
+    let execPromise = mQuery.exec();
 
     if (lean && leanWithId) {
-      docsPromise = docsPromise.then((docs) => {
+      execPromise = execPromise.then((docs) => {
         docs.forEach((doc) => {
           if (doc._id) {
             doc.id = String(doc._id);
@@ -223,87 +270,106 @@ function paginate(query, options, callback) {
         return docs;
       });
     }
+
+    return execPromise;
   }
 
-  return Promise.all([countPromise, docsPromise])
-    .then((values) => {
-      let count = values[0];
-      const docs = values[1];
+  function buildResult(count, docs) {
+    if (pagination !== true) {
+      count = docs.length;
+    }
 
-      if (pagination !== true) {
-        count = docs.length;
+    const meta = {
+      [labelTotal]: count,
+    };
+
+    let result;
+
+    if (typeof offset !== 'undefined') {
+      meta.offset = offset;
+      page = Math.ceil((offset + 1) / limit);
+    }
+
+    const pages = limit > 0 ? Math.ceil(count / limit) || 1 : null;
+
+    // Setting default values
+    if (labelLimit) meta[labelLimit] = count;
+    if (labelTotalPages) meta[labelTotalPages] = 1;
+    if (labelPage) meta[labelPage] = page;
+    if (labelPagingCounter) meta[labelPagingCounter] = (page - 1) * limit + 1;
+
+    if (labelHasPrevPage) meta[labelHasPrevPage] = false;
+    if (labelHasNextPage) meta[labelHasNextPage] = false;
+    if (labelPrevPage) meta[labelPrevPage] = null;
+    if (labelNextPage) meta[labelNextPage] = null;
+
+    if (pagination) {
+      if (labelLimit) meta[labelLimit] = limit;
+      if (labelTotalPages) meta[labelTotalPages] = pages;
+
+      // Set prev page
+      if (page > 1) {
+        if (labelHasPrevPage) meta[labelHasPrevPage] = true;
+        if (labelPrevPage) meta[labelPrevPage] = page - 1;
+      } else if (page == 1 && typeof offset !== 'undefined' && offset !== 0) {
+        if (labelHasPrevPage) meta[labelHasPrevPage] = true;
+        if (labelPrevPage) meta[labelPrevPage] = 1;
       }
 
-      const meta = {
-        [labelTotal]: count,
-      };
-
-      let result;
-
-      if (typeof offset !== 'undefined') {
-        meta.offset = offset;
-        page = Math.ceil((offset + 1) / limit);
+      // Set next page
+      if (page < pages) {
+        if (labelHasNextPage) meta[labelHasNextPage] = true;
+        if (labelNextPage) meta[labelNextPage] = page + 1;
       }
+    }
 
-      const pages = limit > 0 ? Math.ceil(count / limit) || 1 : null;
+    // Remove customLabels set to false
+    delete meta['false'];
 
-      // Setting default values
-      if (labelLimit) meta[labelLimit] = count;
+    if (limit == 0) {
+      if (labelLimit) meta[labelLimit] = 0;
       if (labelTotalPages) meta[labelTotalPages] = 1;
-      if (labelPage) meta[labelPage] = page;
-      if (labelPagingCounter) meta[labelPagingCounter] = (page - 1) * limit + 1;
-
-      if (labelHasPrevPage) meta[labelHasPrevPage] = false;
-      if (labelHasNextPage) meta[labelHasNextPage] = false;
+      if (labelPage) meta[labelPage] = 1;
+      if (labelPagingCounter) meta[labelPagingCounter] = 1;
       if (labelPrevPage) meta[labelPrevPage] = null;
       if (labelNextPage) meta[labelNextPage] = null;
+      if (labelHasPrevPage) meta[labelHasPrevPage] = false;
+      if (labelHasNextPage) meta[labelHasNextPage] = false;
+    }
 
-      if (pagination) {
-        if (labelLimit) meta[labelLimit] = limit;
-        if (labelTotalPages) meta[labelTotalPages] = pages;
+    if (labelMeta) {
+      result = {
+        [labelDocs]: docs,
+        [labelMeta]: meta,
+      };
+    } else {
+      result = {
+        [labelDocs]: docs,
+        ...meta,
+      };
+    }
 
-        // Set prev page
-        if (page > 1) {
-          if (labelHasPrevPage) meta[labelHasPrevPage] = true;
-          if (labelPrevPage) meta[labelPrevPage] = page - 1;
-        } else if (page == 1 && typeof offset !== 'undefined' && offset !== 0) {
-          if (labelHasPrevPage) meta[labelHasPrevPage] = true;
-          if (labelPrevPage) meta[labelPrevPage] = 1;
-        }
+    return result;
+  }
 
-        // Set next page
-        if (page < pages) {
-          if (labelHasNextPage) meta[labelHasNextPage] = true;
-          if (labelNextPage) meta[labelNextPage] = page + 1;
-        }
-      }
+  const hasSession = hasActiveSession(model, queryOptions);
 
-      // Remove customLabels set to false
-      delete meta['false'];
+  let resultPromise;
+  if (hasSession) {
+    resultPromise = Promise.resolve(countPromise).then((count) => {
+      return buildDocsPromise().then((docs) => {
+        return buildResult(count, docs);
+      });
+    });
+  } else {
+    docsPromise = buildDocsPromise();
+    resultPromise = Promise.all([countPromise, docsPromise]).then((values) => {
+      return buildResult(values[0], values[1]);
+    });
+  }
 
-      if (limit == 0) {
-        if (labelLimit) meta[labelLimit] = 0;
-        if (labelTotalPages) meta[labelTotalPages] = 1;
-        if (labelPage) meta[labelPage] = 1;
-        if (labelPagingCounter) meta[labelPagingCounter] = 1;
-        if (labelPrevPage) meta[labelPrevPage] = null;
-        if (labelNextPage) meta[labelNextPage] = null;
-        if (labelHasPrevPage) meta[labelHasPrevPage] = false;
-        if (labelHasNextPage) meta[labelHasNextPage] = false;
-      }
-
-      if (labelMeta) {
-        result = {
-          [labelDocs]: docs,
-          [labelMeta]: meta,
-        };
-      } else {
-        result = {
-          [labelDocs]: docs,
-          ...meta,
-        };
-      }
-
+  return resultPromise
+    .then((result) => {
       return isCallbackSpecified
         ? callback(null, result)
         : Promise.resolve(result);

--- a/tests/index.js
+++ b/tests/index.js
@@ -5,6 +5,7 @@ let mongooseLeanVirtuals = require('mongoose-lean-virtuals');
 let expect = require('chai').expect;
 let assert = require('chai').assert;
 let mongoosePaginate = require('../dist/index');
+let mongoosePaginateSource = require('../src/index');
 let PaginationParameters = require('../dist/pagination-parameters');
 
 let MONGO_URI = 'mongodb://localhost/mongoose_paginate_test';
@@ -100,6 +101,49 @@ const testDescendingPrice = (result) => {
 
   expect(isSorted).to.be.true;
 };
+
+const controlledPromise = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolveFn, rejectFn) => {
+    resolve = resolveFn;
+    reject = rejectFn;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+};
+
+const stubQuery = (exec) => ({
+  populate() {
+    return this;
+  },
+  select() {
+    return this;
+  },
+  sort() {
+    return this;
+  },
+  lean() {
+    return this;
+  },
+  read() {
+    return this;
+  },
+  skip() {
+    return this;
+  },
+  limit() {
+    return this;
+  },
+  allowDiskUse() {
+    return this;
+  },
+  exec,
+});
 
 BookSchema.plugin(mongoosePaginate);
 
@@ -901,6 +945,387 @@ describe('mongoose-paginate', function () {
       throw err;
     } finally {
       await session.endSession();
+    }
+  });
+
+  it('paginate inside a transaction serializes count and docs when session is set', async function () {
+    // Transactions require a replica set
+    if (
+      !mongoose.connection.client.topology.description.type.includes(
+        'ReplicaSet'
+      )
+    ) {
+      this.skip();
+    }
+
+    const session = await mongoose.startSession();
+    session.startTransaction();
+
+    try {
+      const query = {
+        title: {
+          $in: [/Book/i],
+        },
+      };
+
+      const options = {
+        limit: 10,
+        page: 1,
+        options: {
+          session: session,
+        },
+      };
+
+      const result = await Book.paginate(query, options);
+
+      expect(result.docs).to.have.length(10);
+      expect(result.totalDocs).to.equal(100);
+      expect(result.totalPages).to.equal(10);
+      expect(result.hasNextPage).to.equal(true);
+
+      await session.commitTransaction();
+    } catch (err) {
+      await session.abortTransaction();
+      throw err;
+    } finally {
+      await session.endSession();
+    }
+  });
+
+  it('paginate inside an implicit ALS transaction serializes count and docs', async function () {
+    // Transactions require a replica set
+    if (
+      !mongoose.connection.client.topology.description.type.includes(
+        'ReplicaSet'
+      )
+    ) {
+      this.skip();
+    }
+
+    const originalUseALS = mongoose.get('transactionAsyncLocalStorage');
+    mongoose.set('transactionAsyncLocalStorage', true);
+
+    try {
+      await mongoose.connection.transaction(async function () {
+        const query = {
+          title: {
+            $in: [/Book/i],
+          },
+        };
+
+        const options = {
+          limit: 10,
+          page: 1,
+        };
+
+        const store =
+          Book.db.base.transactionAsyncLocalStorage &&
+          Book.db.base.transactionAsyncLocalStorage.getStore();
+        expect(store).to.be.an('object');
+        expect(store.session).to.exist;
+
+        const result = await Book.paginate(query, options);
+
+        expect(result.docs).to.have.length(10);
+        expect(result.totalDocs).to.equal(100);
+        expect(result.totalPages).to.equal(10);
+        expect(result.hasNextPage).to.equal(true);
+      });
+    } finally {
+      mongoose.set('transactionAsyncLocalStorage', originalUseALS);
+    }
+  });
+
+  it('serializes count and docs when an explicit session is in a transaction', async function () {
+    const originalCountDocuments = Book.countDocuments;
+    const originalFind = Book.find;
+    const countControl = controlledPromise();
+    const docsControl = controlledPromise();
+    let countStarted = false;
+    let docsConstructed = false;
+    let docsStarted = false;
+
+    try {
+      Book.countDocuments = function () {
+        return {
+          exec() {
+            countStarted = true;
+            return countControl.promise;
+          },
+        };
+      };
+
+      Book.find = function () {
+        docsConstructed = true;
+        return stubQuery(function () {
+          docsStarted = true;
+          return docsControl.promise;
+        });
+      };
+
+      const resultPromise = mongoosePaginateSource.paginate.call(
+        Book,
+        { title: 'Serialized explicit session' },
+        {
+          limit: 10,
+          page: 1,
+          options: {
+            session: {
+              id: 'explicit-session',
+              inTransaction() {
+                return true;
+              },
+            },
+          },
+        }
+      );
+
+      expect(countStarted).to.equal(true);
+      expect(docsConstructed).to.equal(false);
+      expect(docsStarted).to.equal(false);
+
+      await Promise.resolve();
+
+      expect(docsConstructed).to.equal(false);
+      expect(docsStarted).to.equal(false);
+
+      countControl.resolve(1);
+      await Promise.resolve();
+
+      expect(docsConstructed).to.equal(true);
+      expect(docsStarted).to.equal(true);
+
+      docsControl.resolve([{ title: 'Serialized explicit session' }]);
+      const result = await resultPromise;
+
+      expect(result.totalDocs).to.equal(1);
+      expect(result.docs).to.have.length(1);
+    } finally {
+      Book.countDocuments = originalCountDocuments;
+      Book.find = originalFind;
+    }
+  });
+
+  it('keeps count and docs parallel when an explicit session is not in a transaction', async function () {
+    const originalCountDocuments = Book.countDocuments;
+    const originalFind = Book.find;
+    const countControl = controlledPromise();
+    const docsControl = controlledPromise();
+    let countStarted = false;
+    let docsStarted = false;
+
+    try {
+      Book.countDocuments = function () {
+        return {
+          exec() {
+            countStarted = true;
+            return countControl.promise;
+          },
+        };
+      };
+
+      Book.find = function () {
+        return stubQuery(function () {
+          docsStarted = true;
+          return docsControl.promise;
+        });
+      };
+
+      const resultPromise = mongoosePaginateSource.paginate.call(
+        Book,
+        { title: 'Parallel explicit session' },
+        {
+          limit: 10,
+          page: 1,
+          options: {
+            session: {
+              id: 'explicit-causal-session',
+              inTransaction() {
+                return false;
+              },
+            },
+          },
+        }
+      );
+
+      expect(countStarted).to.equal(true);
+      expect(docsStarted).to.equal(true);
+
+      countControl.resolve(2);
+      docsControl.resolve([
+        { title: 'Parallel explicit session 1' },
+        { title: 'Parallel explicit session 2' },
+      ]);
+      const result = await resultPromise;
+
+      expect(result.totalDocs).to.equal(2);
+      expect(result.docs).to.have.length(2);
+    } finally {
+      Book.countDocuments = originalCountDocuments;
+      Book.find = originalFind;
+    }
+  });
+
+  it('serializes count and docs when an implicit ALS session is in a transaction', async function () {
+    const originalCountDocuments = Book.countDocuments;
+    const originalFind = Book.find;
+    const base = Book.db.base;
+    const hadTransactionAsyncLocalStorage =
+      Object.prototype.hasOwnProperty.call(
+        base,
+        'transactionAsyncLocalStorage'
+      );
+    const originalTransactionAsyncLocalStorage =
+      base.transactionAsyncLocalStorage;
+    const countControl = controlledPromise();
+    const docsControl = controlledPromise();
+    let countStarted = false;
+    let docsConstructed = false;
+    let docsStarted = false;
+
+    try {
+      base.transactionAsyncLocalStorage = {
+        getStore() {
+          return {
+            session: {
+              id: 'implicit-session',
+              inTransaction() {
+                return true;
+              },
+            },
+          };
+        },
+      };
+
+      Book.countDocuments = function () {
+        return {
+          exec() {
+            countStarted = true;
+            return countControl.promise;
+          },
+        };
+      };
+
+      Book.find = function () {
+        docsConstructed = true;
+        return stubQuery(function () {
+          docsStarted = true;
+          return docsControl.promise;
+        });
+      };
+
+      const resultPromise = mongoosePaginateSource.paginate.call(
+        Book,
+        { title: 'Serialized implicit session' },
+        {
+          limit: 10,
+          page: 1,
+        }
+      );
+
+      expect(countStarted).to.equal(true);
+      expect(docsConstructed).to.equal(false);
+      expect(docsStarted).to.equal(false);
+
+      await Promise.resolve();
+
+      expect(docsConstructed).to.equal(false);
+      expect(docsStarted).to.equal(false);
+
+      countControl.resolve(1);
+      await Promise.resolve();
+
+      expect(docsConstructed).to.equal(true);
+      expect(docsStarted).to.equal(true);
+
+      docsControl.resolve([{ title: 'Serialized implicit session' }]);
+      const result = await resultPromise;
+
+      expect(result.totalDocs).to.equal(1);
+      expect(result.docs).to.have.length(1);
+    } finally {
+      Book.countDocuments = originalCountDocuments;
+      Book.find = originalFind;
+
+      if (hadTransactionAsyncLocalStorage) {
+        base.transactionAsyncLocalStorage =
+          originalTransactionAsyncLocalStorage;
+      } else {
+        delete base.transactionAsyncLocalStorage;
+      }
+    }
+  });
+
+  it('starts count and docs in parallel when no session is active', async function () {
+    const originalCountDocuments = Book.countDocuments;
+    const originalFind = Book.find;
+    const base = Book.db.base;
+    const hadTransactionAsyncLocalStorage =
+      Object.prototype.hasOwnProperty.call(
+        base,
+        'transactionAsyncLocalStorage'
+      );
+    const originalTransactionAsyncLocalStorage =
+      base.transactionAsyncLocalStorage;
+    const countControl = controlledPromise();
+    const docsControl = controlledPromise();
+    let countStarted = false;
+    let docsStarted = false;
+
+    try {
+      base.transactionAsyncLocalStorage = {
+        getStore() {
+          return null;
+        },
+      };
+
+      Book.countDocuments = function () {
+        return {
+          exec() {
+            countStarted = true;
+            return countControl.promise;
+          },
+        };
+      };
+
+      Book.find = function () {
+        return stubQuery(function () {
+          docsStarted = true;
+          return docsControl.promise;
+        });
+      };
+
+      const resultPromise = mongoosePaginateSource.paginate.call(
+        Book,
+        { title: 'Parallel no session' },
+        {
+          limit: 10,
+          page: 1,
+        }
+      );
+
+      expect(countStarted).to.equal(true);
+      expect(docsStarted).to.equal(true);
+
+      countControl.resolve(2);
+      docsControl.resolve([
+        { title: 'Parallel no session 1' },
+        { title: 'Parallel no session 2' },
+      ]);
+      const result = await resultPromise;
+
+      expect(result.totalDocs).to.equal(2);
+      expect(result.docs).to.have.length(2);
+    } finally {
+      Book.countDocuments = originalCountDocuments;
+      Book.find = originalFind;
+
+      if (hadTransactionAsyncLocalStorage) {
+        base.transactionAsyncLocalStorage =
+          originalTransactionAsyncLocalStorage;
+      } else {
+        delete base.transactionAsyncLocalStorage;
+      }
     }
   });
 


### PR DESCRIPTION
This fixes transaction failures caused by count and document queries running concurrently on the same MongoDB session, while preserving parallel execution outside transactions.

### What

- Serialize count and document queries for explicit transaction sessions
- Detect implicit Mongoose AsyncLocalStorage transaction sessions
- Keep queries parallel for non-transactional sessions
- Add deterministic scheduling and replica-set integration tests

### Why

- MongoDB does not support parallel operations within a transaction
- Concurrent pagination queries can produce transaction-number and inactive-transaction errors

### Verification

#### Unit tests

```bash
npm run prepare
npm test
```

On a standalone MongoDB instance this yields **31 passing, 3 replica-set tests skipped**.

#### Replica-set integration tests

Point `tests/index.js` at a replica set, for example:

```js
let MONGO_URI = 'mongodb://127.0.0.1:27018/mongoose_paginate_test?replicaSet=rs0';
```

Then rerun `npm test`. All tests should pass (**34 passing**).

### Reproduction

#### Explicit session

```js
const session = await mongoose.startSession();
session.startTransaction();
await Model.paginate(query, { options: { session } });
await session.commitTransaction();
```

#### Implicit Mongoose 8 ALS session

```js
mongoose.set('transactionAsyncLocalStorage', true);
await mongoose.connection.transaction(async () => {
  await Model.paginate(query);
});
```

Before this fix, both cases could fail with a transaction-number mismatch or inactive-transaction error because count and document queries ran concurrently. After this fix, queries inside a transaction run sequentially, while non-transactional queries remain parallel.
